### PR TITLE
Change HD Scanner window size

### DIFF
--- a/src/Network/providers/AVMWebSocketProvider.ts
+++ b/src/Network/providers/AVMWebSocketProvider.ts
@@ -87,7 +87,7 @@ export default class AVMWebSocketProvider {
      * Creates a bloom filter from the addresses of the tracked wallets and subscribes to
      * transactions on the node.
      */
-    async updateFilterAddresses(): Promise<void> {
+    updateFilterAddresses() {
         if (!this.isConnected) {
             return;
         }
@@ -97,7 +97,7 @@ export default class AVMWebSocketProvider {
         let addrs = [];
         for (let i = 0; i < wallets.length; i++) {
             let w = wallets[i];
-            let externalAddrs = await w.getExternalAddressesX();
+            let externalAddrs = w.getExternalAddressesXSync();
             let addrsLen = externalAddrs.length;
             let startIndex = Math.max(0, addrsLen - FILTER_ADDRESS_SIZE);
             let addAddrs = externalAddrs.slice(startIndex);

--- a/src/Wallet/HdScanner.ts
+++ b/src/Wallet/HdScanner.ts
@@ -12,7 +12,7 @@ import {
     SCAN_RANGE,
     SCAN_SIZE,
 } from './constants';
-import { getAddressChains } from '../Explorer';
+import { getAddressChains } from '@/Explorer';
 import { NO_NETWORK } from '@/errors';
 import { bintools } from '@/common';
 import { sleep } from '@/utils';

--- a/src/Wallet/constants.ts
+++ b/src/Wallet/constants.ts
@@ -10,7 +10,7 @@ export const LEDGER_ETH_ACCOUNT_PATH = ETH_ACCOUNT_PATH + '/0/0';
 
 export const HD_SCAN_GAP_SIZE: number = 20; // a gap of at least 20 indexes is needed to claim an index unused
 export const SCAN_SIZE: number = 70; // the total number of utxos to look at initially to calculate last index
-export const HD_SCAN_LOOK_UP_WINDOW: number = 512; // Number of addresses to check with the explorer at a single call
+export const HD_SCAN_LOOK_UP_WINDOW: number = 64; // Number of addresses to check with the explorer at a single call
 export const SCAN_RANGE: number = SCAN_SIZE - HD_SCAN_GAP_SIZE; // How many items are actually scanned
 
 export const LEDGER_EXCHANGE_TIMEOUT = 90_000;


### PR DESCRIPTION
Changing it from 512 to 64 will help speed up hd index discovery for newer wallets.