### PR TITLE
feat: add currency support for fetching avax price in price_utils

### DIFF
--- a/src/utils/price_utils.ts
+++ b/src/utils/price_utils.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=avalanche-2&vs_currencies=usd';
+const getCoinGeckoURL = (currentCurrency: string) =>
+    `https://api.coingecko.com/api/v3/simple/price?ids=avalanche-2&vs_currencies=${currentCurrency}`;
 
 /**
  * Fetches the current AVAX price using Coin Gecko.
@@ -8,9 +9,9 @@ const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=avalanc
  * You might get rate limited if you use this function frequently.
  *
  * @return
- * Current USD price of 1 AVAX
+ * Current price of 1 AVAX vs a currency (default USD)
  */
-export async function getAvaxPrice(): Promise<number> {
-    const res = await axios.get(COINGECKO_URL);
-    return res.data['avalanche-2'].usd;
+export async function getAvaxPrice(currentCurrency = 'USD'): Promise<number> {
+    const res = await axios.get(getCoinGeckoURL(currentCurrency));
+    return res.data['avalanche-2'][currentCurrency.toLowerCase()];
 }


### PR DESCRIPTION
[Jira](https://ava-labs.atlassian.net/browse/CP-426)

[extension-avalanche PR](https://github.com/ava-labs/extension-avalanche/pull/132)
[wallet-react-components PR](https://github.com/ava-labs/wallet-react-components/pull/26)

This PR allows the SDK to fetch prices for selected currencies

Must be merged before the `extension-avalanche` and `wallet-react-components` PRs