### PR TITLE
fix: increase network event emitter limit to 100

### DIFF
--- a/src/Network/eventEmitter.ts
+++ b/src/Network/eventEmitter.ts
@@ -9,4 +9,7 @@ export function emitNetworkChange(newNetwork: NetworkConfig) {
     networkEvents.emit('network_change', newNetwork);
 }
 
+const MAX_LISTENERS = 100;
+
 export const networkEvents: EventEmitter = new EventEmitter();
+networkEvents.setMaxListeners(MAX_LISTENERS);


### PR DESCRIPTION
mutes the memory leak warning