### PR TITLE
fix: utxo csv export

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
         "xss": "1.0.11"
     },
     "peerDependencies": {
-        "avalanche": "3.15.2"
+        "avalanche": ">= 3.15.2"
     }
 }


### PR DESCRIPTION
- use new line for multi sig addresses